### PR TITLE
drivers: watchdog: rti_wdt: set min_hw_heartbeat_ms to 60%

### DIFF
--- a/drivers/watchdog/rti_wdt.c
+++ b/drivers/watchdog/rti_wdt.c
@@ -85,7 +85,7 @@ static int rti_wdt_start(struct watchdog_device *wdd)
 	 * to be 50% or less than that; we obviouly want to configure the open
 	 * window as large as possible so we select the 50% option.
 	 */
-	wdd->min_hw_heartbeat_ms = 500 * wdd->timeout;
+	wdd->min_hw_heartbeat_ms = 600 * wdd->timeout;
 
 	/* Generate NMI when wdt expires */
 	writel_relaxed(RTIWWDRX_NMI, wdt->base + RTIWWDRXCTRL);


### PR DESCRIPTION
When watchdog is triggered within the 50% then the system reboots. So setting the min_hw_heartbeat_ms property to 60% to relax it.